### PR TITLE
chore: remove Head.rewind usage for Next.js@11

### DIFF
--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -1,6 +1,5 @@
 import { NextPage } from 'next';
 import App from 'next/app';
-import Head from 'next/head';
 import React from 'react';
 import initApollo from './apollo';
 import {
@@ -87,10 +86,6 @@ export default function withApollo<TCache = any>(
                 );
               }
             }
-
-            // getDataFromTree does not call componentWillUnmount
-            // head side effect therefore need to be cleared manually
-            Head.rewind();
 
             apolloState.data = apollo.cache.extract();
           }


### PR DESCRIPTION
### Describe the Bug
since Head.rewind has been a no-op since Next.js 9.5, in Next.js 11 it was removed. So we can safely remove your usage of Head.rewind. Otherwise, the application which using the next@11 will throw error.
`TypeError: head_1.default.rewind is not a function`

### Solution
- remove Head.rewind usage

Could you help take a look and contact me if any issue, thanks so much